### PR TITLE
feat(ci): publish stable release containers to ghcr

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Sync locked EditorConfig tooling
         run: uv sync --locked --only-group dev
       - name: Run editorconfig-checker

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,6 +136,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+      - name: Sync locked EditorConfig tooling
+        run: uv sync --locked --only-group dev
       - name: Run editorconfig-checker
-        # Reads .editorconfig-checker.json (ITM-009).
-        uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
+        # Match local hooks (WL-001). The old action fetches floating binaries;
+        # upstream v4 renamed those assets, so its downloader no longer works.
+        run: uv run --no-sync ec -config .editorconfig-checker.json

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,70 @@
+# Version publication is independent of PyPI and of other release versions.
+name: publish-container
+
+on:
+  release:
+    types: [published]
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  container-check:
+    if: github.event_name != 'release'
+    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Build and smoke-test the container without registry credentials
+        run: python3 scripts/publish_container.py check
+
+  publish-version:
+    if: >-
+      github.event_name == 'release' &&
+      !github.event.release.draft && !github.event.release.prerelease
+    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: container-version-${{ github.event.release.tag_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Publish or verify the released version and check anonymous access
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/publish_container.py publish
+
+  promote-latest:
+    needs: publish-version
+    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    # GitHub can replace a pending promotion. Every surviving job reconciles
+    # the highest published version, including versions from replaced jobs.
+    concurrency:
+      group: container-latest
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Promote the highest published stable version without rebuilding
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/publish_container.py promote

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -20,8 +20,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Build and smoke-test the container without registry credentials
-        run: python3 scripts/publish_container.py check
+        run: >-
+          uv run --no-project --python 3.12 python
+          scripts/publish_container.py check
 
   publish-version:
     if: >-
@@ -41,10 +45,14 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Publish or verify the released version and check anonymous access
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/publish_container.py publish
+        run: >-
+          uv run --no-project --python 3.12 python
+          scripts/publish_container.py publish
 
   promote-latest:
     needs: publish-version
@@ -64,7 +72,11 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Promote the highest published stable version without rebuilding
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/publish_container.py promote
+        run: >-
+          uv run --no-project --python 3.12 python
+          scripts/publish_container.py promote

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,11 @@ with JSON-RPC `initialize`/`shutdown` against `uvx ty@latest server`.
 
 `release-please` opens a release PR on every push to `main`; merging the PR
 cuts a `v*` tag; `publish.yml` uploads to TestPyPI then PyPI via OIDC
-Trusted Publishing. See [ITM-053..060] for the full chain.
+Trusted Publishing. `publish-container.yml` separately publishes the existing
+web-service Docker image to GHCR when a stable GitHub Release is published.
+It uses `GITHUB_TOKEN`, preserves existing version images on retries, and
+checks anonymous access. First publication requires public package visibility.
+See `docs/RELEASE.md` for tags, verification, and recovery.
 
 ## Creating a new project from this template
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ See [AGENTS.md](AGENTS.md) for the canonical command set, [.github/CONTRIBUTING.
 
 The blueprint includes an optional REST API (`uv sync --extra web`, `just serve`) with production best practices already baked in: RFC 9457 problem+json errors, `/v1` versioning, pagination, Idempotency-Key replay, Prometheus metrics, opt-in OpenTelemetry tracing, rate limiting, security headers, typed env settings, a committed OpenAPI snapshot with breaking-change CI (oasdiff) and schemathesis fuzzing, generated typed clients, and a production Dockerfile. See [EXAMPLEWEB.md](EXAMPLEWEB.md) for the service walkthrough (the web counterpart of [EXAMPLECLI.md](EXAMPLECLI.md)), the [web service docs](docs/source/web/index.md), the [WEB-xx convention catalog](docs/design/0002-web-api-conventions.md), and [ADR 0013](docs/adr/0013-web-service-best-practices.md) for the design decisions.
 
+Stable GitHub releases also publish a `linux/amd64` container to
+`ghcr.io/smorinlabs/py-launch-blueprint`. Availability begins with the first
+release containing this workflow and completion of the
+[public-package setup](docs/RELEASE.md#public-container-publishing-ghcr).
+Once available, run the web service locally:
+
+```bash
+docker pull --platform linux/amd64 ghcr.io/smorinlabs/py-launch-blueprint:latest
+docker run --rm --platform linux/amd64 -p 127.0.0.1:8000:8000 ghcr.io/smorinlabs/py-launch-blueprint:latest
+```
+
+The health endpoint is `http://127.0.0.1:8000/healthz`. Each release also has an
+`X.Y.Z` image tag matching its version. Use the `sha256` digest recorded in the
+publishing workflow's summary when a deployment must select exact image bytes.
+Public images can be pulled without signing in.
+
 **Starting a new project from this template?** If you use Claude Code or any agent that reads `AGENTS.md`, just say *"create a new Python project from py-launch-blueprint"* — the [`new-python-project`](.claude/skills/new-python-project/SKILL.md) skill (Claude Code discovers it in `.claude/skills/`; Codex via the `.agents/skills/` symlink) will walk you through `gh repo create --template`, identity collection, and the press rebrand (`uvx --from 'template-press>=3.6.0' press rebrand`, dry-run preview first). For humans without an agent: the skill is also a copy-pasteable runbook. After the press, work through [`docs/POST_INIT.md`](docs/POST_INIT.md) — the checklist of decisions, secrets, and repo settings to configure. Internal engineering docs (ADRs, design specs, research) live under [`docs/`](docs/README.md).
 
 ### 🎯 Perfect For

--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -71,6 +71,14 @@ setup in [§2](#2-checks--configuration).
       needs PyPI + environment config.* File: `.github/workflows/publish.yml`,
       `.pypirc.template` (manual fallback). Remove the workflow if the project is
       not distributed on PyPI.
+- [ ] **Publish the web container to public GHCR** — *Default: on for published
+      stable releases, needs one-time package visibility setup.* File:
+      `.github/workflows/publish-container.yml`; helper:
+      `scripts/publish_container.py`. The image name uses this repository's
+      lowercase owner/name. Remove the workflow if the project does not ship
+      the web image, and adjust the release PR title in
+      `release-please-config.json` to name the channels you kept. See
+      [GHCR setup and recovery](RELEASE.md#public-container-publishing-ghcr).
 - [ ] **Read the Docs hosting** — *Default: configured, needs RTD import.* File:
       `.readthedocs.yaml` + `docs/`. Remove if you don't host docs on RTD.
 - [ ] **Codecov coverage reporting** — *Default: on, tokenless on public repos.*
@@ -121,6 +129,8 @@ Add under **Settings → Secrets and variables → Actions** (or org-level).
 
 > `GITHUB_TOKEN` is provided automatically — no setup. PyPI/TestPyPI publishing
 > uses **OIDC trusted publishing**, so it needs **no secret** (see §2.3).
+> GHCR uses `GITHUB_TOKEN` with job-scoped `packages: write`; do not add a
+> registry password or personal access token. Public pulls need no credential.
 
 ### 2.2 GitHub Environments
 
@@ -145,6 +155,7 @@ scripts/setup-github-environments.sh <owner>/<repo>
 |---|---|---|
 | **CodeQL** | In **Settings → Code security**, ensure **default setup is OFF** (advanced setup is mutually exclusive with it — see `.github/SECURITY.md`). To verify/disable: `gh api /repos/<owner>/<repo>/code-scanning/default-setup` then `gh api --method PATCH … -f state=not-configured`. | `codeql.yml`, `codeql-config.yml` |
 | **PyPI trusted publisher** | On pypi.org (and test.pypi.org) → your project → *Publishing* → add a GitHub Actions trusted publisher: this repo, workflow `publish.yml`, environment `pypi` (`testpypi`). | `publish.yml` |
+| **GHCR package** | After the first upload, set the container package to **Public** and rerun the failed anonymous-access check. Ensure the package grants this repository Actions write access and the organization permits public packages. | `publish-container.yml`; [release instructions](RELEASE.md#public-container-publishing-ghcr) |
 | **Codecov** | Add the repo at codecov.io. Public repos need no token (OIDC). | `.codecov.yml` |
 | **Read the Docs** | Import the project at readthedocs.org; it reads `.readthedocs.yaml`. | `.readthedocs.yaml` |
 | **Dependabot** | Enable **Dependabot version + security updates** in Settings; `dependabot.yml` does the rest. | `.github/dependabot.yml` |
@@ -359,5 +370,4 @@ git commit -m "chore: normalize formatting post-press"
 - `just check` proves the normalization landed before anything is
   committed; with the press committed first, `git add -u` stages exactly
   the formatting deltas.
-
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,11 +10,104 @@ Release flow per ADR-05 + ADR-06 + ADR-07. See
    proposing the next semver bump + a `CHANGELOG.md` entry. Its generated
    commit updates `pyproject.toml` and the editable root entry in `uv.lock`
    atomically, so the PR is internally consistent from its first revision.
-3. Merge the release PR. release-please pushes a `v*` tag.
+3. Merge the release PR. release-please pushes a `v*` tag and publishes a
+   GitHub Release.
 4. The `publish` workflow fires on the tag:
    - `build` job: tag-reachability + version-matches-tag, then `uv build`.
    - `publish-testpypi`: OIDC upload to TestPyPI (env `testpypi`).
    - `publish-pypi`: OIDC upload to PyPI (env `pypi`).
+5. Independently, `publish-container` fires when a stable GitHub Release is
+   published. It builds and tests the web image, publishes the version to
+   GHCR, verifies anonymous access, and reconciles the `latest` image tag.
+
+## Public container publishing (GHCR)
+
+The image is `ghcr.io/smorinlabs/py-launch-blueprint`. Generated projects use
+their own lowercase GitHub owner/repository name. The existing Dockerfile
+supplies the web service, runs as a non-root user, and listens on port `8000`.
+The initial supported platform is `linux/amd64`.
+
+| Reference | Meaning |
+|---|---|
+| `:X.Y.Z` | The image for the published stable release `vX.Y.Z`. The workflow never overwrites an existing version image. |
+| `:latest` | The highest numeric stable version published to this container package, after its health and public-access checks pass. |
+| `@sha256:…` | The exact manifest digest reported by the workflow. Prefer this for repeatable deployments. |
+
+Draft releases, prereleases, and standalone tag pushes do not publish
+containers. Publication begins with the next stable release whose tag includes
+the workflow. Existing releases are not automatically backfilled. The PyPI
+workflow continues to run independently on `v*` tag pushes.
+
+The workflow checks the release tag against the event commit, the checkout,
+`main` ancestry, `pyproject.toml`, and the editable root version in `uv.lock`.
+A new version is built once and tested by its local image ID. The health
+response must report `status: ok` and the released version. The same image is
+pushed, and its registry configuration digest must match the digest recorded
+by Buildx for that build. Docker's local image ID has different meanings on
+its classic and containerd storage backends, so it is not used as a substitute
+for the build's configuration digest. Deployment references use the registry
+manifest digest.
+
+The publisher uses GitHub Actions' automatic `GITHUB_TOKEN` with
+`contents: read` and `packages: write`. No stored GHCR credential is needed.
+The release-please App/PAT described below remains responsible for creating
+release events that can trigger downstream workflows.
+
+### First public publication
+
+GHCR creates new packages as **Private**, including packages linked to public
+repositories. The first run can therefore upload successfully and then fail
+its anonymous pull check. The uploaded version is retained for the retry.
+
+1. After that first upload, open
+   [this repository](https://github.com/smorinlabs/py-launch-blueprint), select
+   the container under **Packages**, then open **Package settings**.
+2. Under **Danger Zone**, select **Change visibility**, choose **Public**,
+   and confirm the package name. GitHub does not allow a public package to
+   become private again. An organization owner must allow public package
+   creation if organization policy currently forbids it.
+3. Rerun the failed `publish-container` workflow from the release's Actions
+   run. Success requires a pull by digest with an empty Docker credential
+   configuration, followed by `latest` promotion. Each subsequent version
+   uses the package's public visibility.
+
+If the package existed before this workflow, verify that its **Manage Actions
+access** grants this repository write access. A repository association alone
+does not guarantee write access when permission inheritance is disabled.
+
+### Retries and concurrent releases
+
+An existing version is pulled by digest, its source/revision/version labels
+are validated, and its health is tested again. It is never rebuilt or pushed
+again. Registry authentication and transport errors stop publication; only an
+explicit missing-manifest response permits a new build. A conflicting version
+requires investigation and a new release, not an overwrite.
+
+Version jobs serialize by release tag, so different releases can publish
+independently. Promotion jobs serialize across the package. GitHub can cancel
+an older pending promotion when another arrives. Every surviving promotion
+reconciles the highest published stable version, including versions uploaded
+by runs whose promotion was canceled. It copies the exact version manifest to
+`latest` and refuses a version regression or conflicting digest. These rules
+protect writes from this workflow; package administrators can still change
+tags outside it, which is why deployment consumers should pin digests.
+
+A canceled run may already have completed version publication. Check its
+`publish-version` job and the later promotion's summary, or rerun the canceled
+run. Retries are also the recovery path for transient registry/network failures.
+GitHub reruns execute the workflow from the original release tag, so a later
+workflow fix on `main` does not repair an old release run. Use a new stable
+release containing that fix. There is no arbitrary-ref publishing dispatch.
+
+Pull requests and merge queues run a build and smoke test without registry
+credentials. The release job always repeats the container check before a new
+publication. The standalone `container-check` job is not automatically a
+required branch-protection check; selecting it as a required check is a
+separate repository setting.
+
+References: [GitHub container authentication and image operations](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry),
+[package visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility),
+[workflow concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
 
 ## Disabling release-please (downstream projects)
 
@@ -25,11 +118,16 @@ If a generated project doesn't want PR-driven version proposals:
 mv .github/workflows/release-please.yml .github/workflows/release-please.yml.disabled
 # Then bump [project] version manually before tagging:
 $EDITOR pyproject.toml
+uv lock
+$EDITOR .release-please-manifest.json
 git tag -a v1.2.3 -m "v1.2.3"
 git push origin v1.2.3
 ```
 
 The `publish` workflow still fires on the tag and uploads to PyPI.
+To publish the container too, publish a stable GitHub Release for that tag.
+Keep the package, lockfile, and release manifest versions consistent before
+committing and tagging.
 
 ## Token setup
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "a58f62dd4fa9c37ad84146dd9e03e5ce938749b1",
-  "pull-request-title-pattern": "chore(release): publish v${version} — review and merge to ship to PyPI",
+  "pull-request-title-pattern": "chore(release): publish v${version} — review and merge to ship to PyPI and GHCR",
   "packages": {
     ".": {
       "release-type": "python",

--- a/scripts/publish_container.py
+++ b/scripts/publish_container.py
@@ -182,9 +182,13 @@ class Registry:
         if "sha256:" + hashlib.sha256(raw).hexdigest() != manifest.config:
             raise ValueError("Image configuration digest does not match its bytes")
         config = json.loads(raw)
-        if (config.get("os"), config.get("architecture")) != ("linux", "amd64"):
+        if not isinstance(config, dict) or (
+            config.get("os"),
+            config.get("architecture"),
+        ) != ("linux", "amd64"):
             raise ValueError("Expected a linux/amd64 image")
-        labels = config["config"]["Labels"]
+        image_config = config.get("config")
+        labels = image_config.get("Labels") if isinstance(image_config, dict) else None
         if not isinstance(labels, dict) or not all(
             isinstance(key, str) and isinstance(value, str)
             for key, value in labels.items()

--- a/scripts/publish_container.py
+++ b/scripts/publish_container.py
@@ -296,7 +296,8 @@ def smoke_test(image_id: str, version: str) -> None:
     )
     probe = (
         "import json, os, urllib.request; "
-        "health=json.load(urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2)); "
+        "health=json.load(urllib.request.urlopen("
+        "'http://127.0.0.1:8000/healthz', timeout=2)); "
         "print(json.dumps({'health': health, 'uid': os.geteuid()}))"
     )
     try:

--- a/scripts/publish_container.py
+++ b/scripts/publish_container.py
@@ -1,0 +1,493 @@
+"""Build, verify, and publish the web image without rebuilding released versions.
+
+The workflow supplies GitHub's short-lived token. Registry errors fail closed;
+only an explicit missing-manifest response permits a new version to be built.
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import tomllib
+from dataclasses import dataclass
+from http.client import HTTPMessage
+from pathlib import Path
+from typing import IO, override
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urljoin, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+ROOT = Path(__file__).resolve().parents[1]
+STABLE = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+REVISION = re.compile(r"[0-9a-f]{40}")
+MEDIA_TYPES = (
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+)
+INDEX_MEDIA_TYPES = (
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+)
+
+
+class RegistryRedirects(HTTPRedirectHandler):
+    """Signed blob redirects must not receive the registry's bearer token."""
+
+    @override
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        if urlsplit(newurl).scheme != "https":
+            raise ValueError("Registry redirect requires HTTPS")
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is not None:
+            redirected.remove_header("Authorization")
+            redirected.remove_header("Proxy-authorization")
+        return redirected
+
+
+OPENER = build_opener(RegistryRedirects())
+
+
+def version_number(value: str) -> tuple[int, int, int]:
+    match = STABLE.fullmatch(value)
+    if not match:
+        raise ValueError(f"Expected a stable X.Y.Z version, got {value!r}")
+    return int(match[1]), int(match[2]), int(match[3])
+
+
+def run(
+    *args: str, env: dict[str, str] | None = None, input_text: str | None = None
+) -> str:
+    executable = shutil.which(args[0])
+    if executable is None:
+        raise RuntimeError(f"Required executable is missing: {args[0]}")
+    result = subprocess.run(  # noqa: S603 -- argument vector, never a shell
+        [executable, *args[1:]],
+        cwd=ROOT,
+        env=env,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=900,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeError(f"{args[0]} {args[1]} failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+@dataclass(frozen=True)
+class Manifest:
+    raw: bytes
+    digest: str
+    config: str
+    media_type: str
+
+
+@dataclass(frozen=True)
+class BuiltImage:
+    image_id: str
+    config_digest: str
+
+
+class Registry:
+    """The small authenticated subset of the OCI distribution API used here."""
+
+    def __init__(self, repository: str) -> None:
+        self.repository = repository
+        query = urlencode(
+            {"service": "ghcr.io", "scope": f"repository:{repository}:pull,push"}
+        )
+        credentials = f"{os.environ['GITHUB_ACTOR']}:{os.environ['GHCR_TOKEN']}"
+        basic = base64.b64encode(credentials.encode()).decode()
+        request = Request(
+            f"https://ghcr.io/token?{query}",
+            headers={"Authorization": f"Basic {basic}"},
+        )
+        with OPENER.open(request, timeout=30) as response:
+            token = json.load(response)["token"]
+        if not isinstance(token, str) or not token:
+            raise ValueError("Registry did not return an authentication token")
+        self.headers = {"Authorization": f"Bearer {token}"}
+
+    def request(
+        self, path: str, *, data: bytes | None = None, media_type: str | None = None
+    ) -> tuple[bytes, dict[str, str]]:
+        url = urljoin("https://ghcr.io", path)
+        parts = urlsplit(url)
+        if parts.scheme != "https" or parts.netloc != "ghcr.io":
+            raise ValueError("Registry pagination attempted to leave ghcr.io")
+        if (
+            parts.path != f"/v2/{self.repository}/tags/list"
+            and not parts.path.startswith(
+                (f"/v2/{self.repository}/manifests/", f"/v2/{self.repository}/blobs/")
+            )
+        ):
+            raise ValueError("Unexpected registry path")
+        # GHCR reports MANIFEST_UNKNOWN when an existing index is not accepted.
+        # Request indexes too, then refuse them explicitly in manifest().
+        headers = {
+            **self.headers,
+            "Accept": ", ".join((*MEDIA_TYPES, *INDEX_MEDIA_TYPES)),
+        }
+        if media_type:
+            headers["Content-Type"] = media_type
+        request = Request(  # noqa: S310 -- validated HTTPS host and repository path
+            url, data=data, headers=headers, method="PUT" if data else "GET"
+        )
+        with OPENER.open(request, timeout=30) as response:
+            return response.read(), {
+                key.lower(): value for key, value in response.headers.items()
+            }
+
+    def manifest(self, tag: str) -> Manifest | None:
+        try:
+            raw, headers = self.request(f"/v2/{self.repository}/manifests/{tag}")
+        except HTTPError as error:
+            if error.code != 404:
+                raise
+            body = json.load(error)
+            codes = {entry.get("code") for entry in body.get("errors", [])}
+            if not codes or not codes <= {"MANIFEST_UNKNOWN", "NAME_UNKNOWN"}:
+                raise
+            return None
+        digest = "sha256:" + hashlib.sha256(raw).hexdigest()
+        if headers.get("docker-content-digest") != digest:
+            raise ValueError("Registry manifest digest does not match its bytes")
+        document = json.loads(raw)
+        media_type = document.get("mediaType")
+        if media_type not in MEDIA_TYPES:
+            raise ValueError("Expected a single-platform image manifest")
+        config = document["config"]["digest"]
+        if not DIGEST.fullmatch(config):
+            raise ValueError("Invalid image configuration digest")
+        return Manifest(raw, digest, config, media_type)
+
+    def labels(self, manifest: Manifest) -> dict[str, str]:
+        raw, _ = self.request(f"/v2/{self.repository}/blobs/{manifest.config}")
+        if "sha256:" + hashlib.sha256(raw).hexdigest() != manifest.config:
+            raise ValueError("Image configuration digest does not match its bytes")
+        config = json.loads(raw)
+        if (config.get("os"), config.get("architecture")) != ("linux", "amd64"):
+            raise ValueError("Expected a linux/amd64 image")
+        labels = config["config"]["Labels"]
+        if not isinstance(labels, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in labels.items()
+        ):
+            raise ValueError("Expected string image labels")
+        return labels
+
+    def versions(self) -> list[str]:
+        path = f"/v2/{self.repository}/tags/list?n=1000"
+        seen: set[str] = set()
+        versions: set[str] = set()
+        while path:
+            if path in seen:
+                raise ValueError("Registry pagination repeated a page")
+            seen.add(path)
+            raw, headers = self.request(path)
+            for tag in json.loads(raw).get("tags") or []:
+                if STABLE.fullmatch(tag):
+                    versions.add(tag)
+            link = headers.get("link", "")
+            if link:
+                match = re.fullmatch(r'<([^>]+)>;\s*rel="next"', link)
+                if not match:
+                    raise ValueError("Unexpected registry pagination link")
+                path = match[1]
+            else:
+                path = ""
+        return sorted(versions, key=version_number)
+
+    def promote(self, manifest: Manifest) -> None:
+        self.request(
+            f"/v2/{self.repository}/manifests/latest",
+            data=manifest.raw,
+            media_type=manifest.media_type,
+        )
+        actual = self.manifest("latest")
+        if actual is None or actual.digest != manifest.digest:
+            raise ValueError("latest did not retain the version's manifest digest")
+
+
+def repository_name() -> str:
+    repository = os.environ["GITHUB_REPOSITORY"].lower()
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9._-]*", repository):
+        raise ValueError("Invalid GitHub owner/repository")
+    return repository
+
+
+def source_version() -> str:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    version = project["project"]["version"]
+    version_number(version)
+    lock = tomllib.loads((ROOT / "uv.lock").read_text())
+    root_versions = [
+        package["version"]
+        for package in lock["package"]
+        if package.get("source", {}).get("editable") == "."
+    ]
+    if root_versions != [version]:
+        raise ValueError("uv.lock editable root version does not match pyproject.toml")
+    return version
+
+
+def release_revision(version: str) -> str:
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    release = event["release"]
+    tag = f"v{version}"
+    if (
+        os.environ["GITHUB_EVENT_NAME"] != "release"
+        or event["action"] != "published"
+        or release["draft"] is not False
+        or release["prerelease"] is not False
+        or release["tag_name"] != tag
+        or os.environ["GITHUB_REF"] != f"refs/tags/{tag}"
+    ):
+        raise ValueError("Publishing requires a matching published stable release")
+    revision = run("git", "rev-parse", "HEAD")
+    if (
+        revision != os.environ["GITHUB_SHA"]
+        or run("git", "rev-parse", f"refs/tags/{tag}^{{commit}}") != revision
+    ):
+        raise ValueError("Release tag, event commit, and checkout disagree")
+    run("git", "merge-base", "--is-ancestor", revision, "refs/remotes/origin/main")
+    return revision
+
+
+def verify_labels(
+    labels: dict[str, str], repository: str, version: str, revision: str | None = None
+) -> None:
+    actual_revision = labels.get("org.opencontainers.image.revision", "")
+    if (
+        labels.get("org.opencontainers.image.source")
+        != f"https://github.com/{repository}"
+        or labels.get("org.opencontainers.image.version") != version
+        or not REVISION.fullmatch(actual_revision)
+        or (revision is not None and actual_revision != revision)
+    ):
+        raise ValueError("Existing image source, version, or revision conflicts")
+
+
+def smoke_test(image_id: str, version: str) -> None:
+    if not DIGEST.fullmatch(image_id):
+        raise ValueError("Smoke tests must run an exact local image ID")
+    container = run(
+        "docker", "run", "--platform=linux/amd64", "--detach", "--pull=never", image_id
+    )
+    probe = (
+        "import json, os, urllib.request; "
+        "health=json.load(urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2)); "
+        "print(json.dumps({'health': health, 'uid': os.geteuid()}))"
+    )
+    try:
+        deadline = time.monotonic() + 90
+        while True:
+            try:
+                result = json.loads(
+                    run("docker", "exec", container, "python", "-c", probe)
+                )
+                break
+            except RuntimeError:
+                if (
+                    time.monotonic() >= deadline
+                    or run(
+                        "docker", "inspect", "--format", "{{.State.Running}}", container
+                    )
+                    != "true"
+                ):
+                    raise
+                time.sleep(1)
+        if (
+            result["health"].get("status") != "ok"
+            or result["health"].get("version") != version
+        ):
+            raise ValueError("Container health response does not match the release")
+        if result["uid"] == 0:
+            raise ValueError("Container runs as root")
+        print(
+            f"Smoke test passed: version {version}, uid {result['uid']}, {image_id}",
+            flush=True,
+        )
+    finally:
+        run("docker", "rm", "--force", container)
+
+
+def build(repository: str, version: str, revision: str) -> BuiltImage:
+    image = f"ghcr.io/{repository}:{version}"
+    print(f"Building and testing {image}", flush=True)
+    with tempfile.TemporaryDirectory(prefix="ghcr-build-") as directory:
+        metadata = Path(directory) / "metadata.json"
+        run(
+            "docker",
+            "buildx",
+            "build",
+            "--load",
+            "--platform",
+            "linux/amd64",
+            "--provenance=false",
+            "--metadata-file",
+            str(metadata),
+            "--label",
+            f"org.opencontainers.image.source=https://github.com/{repository}",
+            "--label",
+            f"org.opencontainers.image.version={version}",
+            "--label",
+            f"org.opencontainers.image.revision={revision}",
+            "--tag",
+            image,
+            ".",
+        )
+        config_digest = json.loads(metadata.read_text())["containerimage.config.digest"]
+        if not DIGEST.fullmatch(config_digest):
+            raise ValueError("Buildx did not record a valid configuration digest")
+    image_id = run("docker", "image", "inspect", "--format", "{{.Id}}", image)
+    smoke_test(image_id, version)
+    return BuiltImage(image_id, config_digest)
+
+
+def pull_test(
+    repository: str, version: str, manifest: Manifest, env: dict[str, str]
+) -> None:
+    reference = f"ghcr.io/{repository}@{manifest.digest}"
+    run(
+        "docker",
+        "pull",
+        "--platform=linux/amd64",
+        reference,
+        env=env,
+    )
+    # Docker's classic store uses a config ID; containerd uses a manifest ID.
+    # Resolve the runnable ID from the immutable reference on either backend.
+    image_id = run(
+        "docker", "image", "inspect", "--format", "{{.Id}}", reference, env=env
+    )
+    smoke_test(image_id, version)
+
+
+def verify_public(repository: str, manifest: Manifest) -> None:
+    with tempfile.TemporaryDirectory(prefix="ghcr-anonymous-") as directory:
+        env = {**os.environ, "DOCKER_CONFIG": directory}
+        try:
+            run(
+                "docker",
+                "pull",
+                "--platform=linux/amd64",
+                f"ghcr.io/{repository}@{manifest.digest}",
+                env=env,
+            )
+        except RuntimeError as error:
+            raise RuntimeError(
+                "Anonymous pull failed. The image may still be private. Set the GHCR "
+                "package visibility to Public, then rerun this release; it will reuse "
+                "the published image. If already public, check the registry error."
+            ) from error
+
+
+def publish(
+    repository: str,
+    version: str,
+    revision: str,
+    registry: Registry,
+    env: dict[str, str],
+) -> Manifest:
+    manifest = registry.manifest(version)
+    if manifest is not None:
+        verify_labels(registry.labels(manifest), repository, version, revision)
+        print(f"Reusing ghcr.io/{repository}@{manifest.digest}", flush=True)
+        pull_test(repository, version, manifest, env)
+    else:
+        built = build(repository, version, revision)
+        image = f"ghcr.io/{repository}:{version}"
+        run("docker", "tag", built.image_id, image)
+        run("docker", "push", "--platform=linux/amd64", image, env=env)
+        manifest = registry.manifest(version)
+        if manifest is None or manifest.config != built.config_digest:
+            raise ValueError("Published image is not the exact smoke-tested image")
+        verify_labels(registry.labels(manifest), repository, version, revision)
+    verify_public(repository, manifest)
+    return manifest
+
+
+def promote_latest(
+    repository: str, registry: Registry, env: dict[str, str]
+) -> Manifest:
+    versions = registry.versions()
+    if not versions:
+        raise ValueError("No published stable container version exists")
+    version = versions[-1]
+    candidate = registry.manifest(version)
+    if candidate is None:
+        raise ValueError("Newest version disappeared during promotion")
+    verify_labels(registry.labels(candidate), repository, version)
+    current = registry.manifest("latest")
+    if current is not None:
+        labels = registry.labels(current)
+        current_version = labels.get("org.opencontainers.image.version", "")
+        verify_labels(labels, repository, current_version)
+        if version_number(current_version) > version_number(version):
+            raise ValueError(
+                "Refusing to move latest backward; a version tag may have been deleted"
+            )
+        if current_version == version and current.digest != candidate.digest:
+            raise ValueError("Existing latest conflicts with the same version tag")
+    # A different release's promotion may have been replaced while pending.
+    # Reconcile the highest registry version, regardless of this run's trigger.
+    pull_test(repository, version, candidate, env)
+    verify_public(repository, candidate)
+    registry.promote(candidate)
+    return candidate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("check", "publish", "promote"))
+    operation = parser.parse_args().operation
+    repository = repository_name()
+    if operation == "check":
+        build(repository, source_version(), run("git", "rev-parse", "HEAD"))
+        return
+    version = source_version()
+    revision = release_revision(version)
+    registry = Registry(repository)
+    with tempfile.TemporaryDirectory(prefix="ghcr-publisher-") as directory:
+        env = {**os.environ, "DOCKER_CONFIG": directory}
+        run(
+            "docker",
+            "login",
+            "ghcr.io",
+            "--username",
+            os.environ["GITHUB_ACTOR"],
+            "--password-stdin",
+            env=env,
+            input_text=os.environ["GHCR_TOKEN"],
+        )
+        manifest = (
+            publish(repository, version, revision, registry, env)
+            if operation == "publish"
+            else promote_latest(repository, registry, env)
+        )
+    reference = f"ghcr.io/{repository}@{manifest.digest}"
+    print(f"Verified public image: {reference}")
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary).open("a") as stream:
+            stream.write(f"Public container ({operation}): `{reference}`\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/meta/test_publish_container.py
+++ b/tests/meta/test_publish_container.py
@@ -1,0 +1,401 @@
+"""Behavioral guards for release replay, publication identity, and promotion."""
+
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+from http.client import HTTPMessage
+from pathlib import Path
+from unittest.mock import Mock
+from urllib.error import HTTPError
+from urllib.request import Request
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "publish_container", ROOT / "scripts/publish_container.py"
+)
+pub = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pub
+SPEC.loader.exec_module(pub)
+
+REPOSITORY = "example-org/service"
+REVISION = "a" * 40
+IMAGE_ID = "sha256:" + "b" * 64
+CONFIG_DIGEST = "sha256:" + "e" * 64
+
+
+def image(version="2.10.0", revision=REVISION, config=CONFIG_DIGEST):
+    raw = json.dumps(
+        {"mediaType": pub.MEDIA_TYPES[0], "config": {"digest": config}}
+    ).encode()
+    manifest = pub.Manifest(
+        raw, "sha256:" + hashlib.sha256(raw).hexdigest(), config, pub.MEDIA_TYPES[0]
+    )
+    labels = {
+        "org.opencontainers.image.source": f"https://github.com/{REPOSITORY}",
+        "org.opencontainers.image.version": version,
+        "org.opencontainers.image.revision": revision,
+    }
+    return manifest, labels
+
+
+@pytest.fixture
+def effects(monkeypatch):
+    mocks = {}
+    for name in ("build", "run", "pull_test", "verify_public"):
+        mocks[name] = Mock(
+            return_value=pub.BuiltImage(IMAGE_ID, CONFIG_DIGEST)
+            if name == "build"
+            else None
+        )
+        monkeypatch.setattr(pub, name, mocks[name])
+    return mocks
+
+
+def test_first_publish_pushes_the_tested_id(effects):
+    manifest, labels = image()
+    registry = Mock(spec=pub.Registry)
+    registry.manifest.side_effect = [None, manifest]
+    registry.labels.return_value = labels
+
+    assert pub.publish(REPOSITORY, "2.10.0", REVISION, registry, {}) == manifest
+
+    effects["build"].assert_called_once_with(REPOSITORY, "2.10.0", REVISION)
+    assert effects["run"].call_args_list[0].args == (
+        "docker",
+        "tag",
+        IMAGE_ID,
+        f"ghcr.io/{REPOSITORY}:2.10.0",
+    )
+    assert effects["run"].call_args_list[1].args == (
+        "docker",
+        "push",
+        "--platform=linux/amd64",
+        f"ghcr.io/{REPOSITORY}:2.10.0",
+    )
+    effects["verify_public"].assert_called_once_with(REPOSITORY, manifest)
+
+
+@pytest.mark.parametrize("docker_id", [IMAGE_ID, CONFIG_DIGEST])
+def test_build_binds_config_digest_independently_of_docker_storage_backend(
+    monkeypatch, docker_id
+):
+    def commands(*args):
+        if args[1] == "buildx":
+            metadata = Path(args[args.index("--metadata-file") + 1])
+            metadata.write_text(
+                json.dumps({"containerimage.config.digest": CONFIG_DIGEST})
+            )
+            return ""
+        return docker_id
+
+    monkeypatch.setattr(pub, "run", commands)
+    smoke = Mock()
+    monkeypatch.setattr(pub, "smoke_test", smoke)
+    assert pub.build(REPOSITORY, "2.10.0", REVISION) == pub.BuiltImage(
+        docker_id, CONFIG_DIGEST
+    )
+    smoke.assert_called_once_with(docker_id, "2.10.0")
+
+
+def test_digest_pull_resolves_the_daemons_runnable_id(monkeypatch):
+    manifest, _ = image()
+    commands = Mock(side_effect=["", IMAGE_ID])
+    monkeypatch.setattr(pub, "run", commands)
+    smoke = Mock()
+    monkeypatch.setattr(pub, "smoke_test", smoke)
+    pub.pull_test(REPOSITORY, "2.10.0", manifest, {})
+    assert commands.call_args.args[-1] == f"ghcr.io/{REPOSITORY}@{manifest.digest}"
+    smoke.assert_called_once_with(IMAGE_ID, "2.10.0")
+
+
+def test_rerun_reuses_existing_digest_without_building_or_pushing(effects):
+    manifest, labels = image()
+    registry = Mock(spec=pub.Registry)
+    registry.manifest.return_value = manifest
+    registry.labels.return_value = labels
+
+    pub.publish(REPOSITORY, "2.10.0", REVISION, registry, {})
+
+    effects["build"].assert_not_called()
+    effects["run"].assert_not_called()
+    effects["pull_test"].assert_called_once_with(REPOSITORY, "2.10.0", manifest, {})
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("org.opencontainers.image.revision", "c" * 40),
+        ("org.opencontainers.image.source", "https://github.com/somewhere/else"),
+        ("org.opencontainers.image.version", "2.9.0"),
+    ],
+)
+def test_conflicting_existing_version_stops_before_any_write(effects, key, value):
+    manifest, labels = image()
+    labels[key] = value
+    registry = Mock(spec=pub.Registry)
+    registry.manifest.return_value = manifest
+    registry.labels.return_value = labels
+
+    with pytest.raises(ValueError, match="conflicts"):
+        pub.publish(REPOSITORY, "2.10.0", REVISION, registry, {})
+    for effect in effects.values():
+        effect.assert_not_called()
+
+
+def test_registry_failure_does_not_authorize_a_build(effects):
+    registry = Mock(spec=pub.Registry)
+    registry.manifest.side_effect = HTTPError(
+        "https://ghcr.io", 401, "denied", {}, None
+    )
+    with pytest.raises(HTTPError):
+        pub.publish(REPOSITORY, "2.10.0", REVISION, registry, {})
+    effects["build"].assert_not_called()
+    effects["run"].assert_not_called()
+
+
+def test_push_with_different_config_is_not_accepted(effects):
+    manifest, _ = image(config="sha256:" + "d" * 64)
+    registry = Mock(spec=pub.Registry)
+    registry.manifest.side_effect = [None, manifest]
+    with pytest.raises(ValueError, match="exact smoke-tested image"):
+        pub.publish(REPOSITORY, "2.10.0", REVISION, registry, {})
+    effects["verify_public"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "code", "missing"),
+    [
+        (404, "MANIFEST_UNKNOWN", True),
+        (404, "NAME_UNKNOWN", True),
+        (404, "UNAUTHORIZED", False),
+        (403, "DENIED", False),
+        (401, "UNAUTHORIZED", False),
+        (500, "MANIFEST_UNKNOWN", False),
+    ],
+)
+def test_only_explicit_missing_manifest_responses_allow_publication(
+    status, code, missing
+):
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    body = io.BytesIO(json.dumps({"errors": [{"code": code}]}).encode())
+    registry.request = Mock(
+        side_effect=HTTPError("https://ghcr.io", status, code, {}, body)
+    )
+    if missing:
+        assert registry.manifest("2.10.0") is None
+    else:
+        with pytest.raises(HTTPError):
+            registry.manifest("2.10.0")
+
+
+def test_manifest_digest_is_verified_against_received_bytes():
+    manifest, _ = image()
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    registry.request = Mock(
+        return_value=(manifest.raw, {"docker-content-digest": manifest.digest})
+    )
+    assert registry.manifest("2.10.0") == manifest
+    registry.request.return_value = (manifest.raw, {"docker-content-digest": IMAGE_ID})
+    with pytest.raises(ValueError, match="digest does not match"):
+        registry.manifest("2.10.0")
+
+
+def test_existing_index_is_detected_and_refused_not_mistaken_for_absence(monkeypatch):
+    raw = json.dumps({"mediaType": pub.INDEX_MEDIA_TYPES[0], "manifests": []}).encode()
+    digest = "sha256:" + hashlib.sha256(raw).hexdigest()
+
+    def server(request, timeout):
+        # Reproduce GHCR's real content negotiation: an unaccepted index looks
+        # missing even though the version tag is occupied.
+        if pub.INDEX_MEDIA_TYPES[0] not in request.get_header("Accept"):
+            body = io.BytesIO(
+                json.dumps({"errors": [{"code": "MANIFEST_UNKNOWN"}]}).encode()
+            )
+            raise HTTPError(request.full_url, 404, "Not Found", {}, body)
+        response = io.BytesIO(raw)
+        response.headers = {"Docker-Content-Digest": digest}
+        return response
+
+    monkeypatch.setattr(pub.OPENER, "open", server)
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    registry.headers = {}
+    with pytest.raises(ValueError, match="single-platform"):
+        registry.manifest("2.10.0")
+
+
+def test_versions_are_numeric_stable_and_paginated():
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    registry.request = Mock(
+        side_effect=[
+            (
+                json.dumps(
+                    {"tags": ["2.9.0", "2.10.0-rc.1", "latest", "02.0.0"]}
+                ).encode(),
+                {"link": f'</v2/{REPOSITORY}/tags/list?last=2.9.0>; rel="next"'},
+            ),
+            (json.dumps({"tags": ["2.10.0", "1.0.0"]}).encode(), {}),
+        ]
+    )
+    assert registry.versions() == ["1.0.0", "2.9.0", "2.10.0"]
+
+
+def test_registry_pagination_cannot_send_credentials_to_another_host():
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    with pytest.raises(ValueError, match=r"leave ghcr\.io"):
+        registry.request("https://example.com/steal")
+
+
+def test_blob_redirect_strips_registry_credentials():
+    request = Request(
+        "https://ghcr.io/v2/example-org/service/blobs/sha256:abc",
+        headers={"Authorization": "Bearer test-only"},
+    )
+    redirected = pub.RegistryRedirects().redirect_request(
+        request,
+        io.BytesIO(),
+        307,
+        "Redirect",
+        HTTPMessage(),
+        "https://pkg-containers.githubusercontent.com/signed-blob",
+    )
+    assert redirected.get_header("Authorization") is None
+    with pytest.raises(ValueError, match="requires HTTPS"):
+        pub.RegistryRedirects().redirect_request(
+            request,
+            io.BytesIO(),
+            307,
+            "Redirect",
+            HTTPMessage(),
+            "http://example.com/insecure-blob",
+        )
+
+
+def test_old_promotion_selects_the_highest_published_version(effects):
+    newest, labels = image("2.10.0")
+    registry = Mock(spec=pub.Registry)
+    registry.versions.return_value = ["2.9.0", "2.10.0"]
+    registry.manifest.side_effect = [newest, None]
+    registry.labels.return_value = labels
+
+    # The helper intentionally takes no triggering version. A surviving old
+    # job must also cover a newer promotion that GitHub replaced while pending.
+    assert pub.promote_latest(REPOSITORY, registry, {}) == newest
+    registry.manifest.assert_any_call("2.10.0")
+    registry.promote.assert_called_once_with(newest)
+    effects["pull_test"].assert_called_once_with(REPOSITORY, "2.10.0", newest, {})
+    effects["build"].assert_not_called()
+
+
+@pytest.mark.parametrize("current_version", ["3.0.0", "2.10.0"])
+def test_latest_does_not_regress_or_replace_conflicting_bytes(effects, current_version):
+    candidate, candidate_labels = image()
+    current, current_labels = image(current_version, config="sha256:" + "c" * 64)
+    registry = Mock(spec=pub.Registry)
+    registry.versions.return_value = ["2.10.0"]
+    registry.manifest.side_effect = [candidate, current]
+    registry.labels.side_effect = [candidate_labels, current_labels]
+
+    with pytest.raises(ValueError, match=r"backward|conflicts"):
+        pub.promote_latest(REPOSITORY, registry, {})
+    registry.promote.assert_not_called()
+
+
+def test_promotion_copies_manifest_bytes_without_wrapping_in_an_index():
+    manifest, _ = image()
+    registry = object.__new__(pub.Registry)
+    registry.repository = REPOSITORY
+    registry.request = Mock()
+    registry.manifest = Mock(return_value=manifest)
+    registry.promote(manifest)
+    registry.request.assert_called_once_with(
+        f"/v2/{REPOSITORY}/manifests/latest",
+        data=manifest.raw,
+        media_type=manifest.media_type,
+    )
+
+
+def test_public_check_uses_an_empty_temporary_docker_configuration(monkeypatch):
+    manifest, _ = image()
+    directories = []
+
+    def pull(*args, env):
+        directory = Path(env["DOCKER_CONFIG"])
+        directories.append(directory)
+        assert directory.is_dir()
+        assert list(directory.iterdir()) == []
+        assert args == (
+            "docker",
+            "pull",
+            "--platform=linux/amd64",
+            f"ghcr.io/{REPOSITORY}@{manifest.digest}",
+        )
+
+    monkeypatch.setattr(pub, "run", pull)
+    pub.verify_public(REPOSITORY, manifest)
+    assert len(directories) == 1
+    assert not directories[0].exists()
+
+
+@pytest.fixture
+def release_event(monkeypatch, tmp_path):
+    event = {
+        "action": "published",
+        "release": {"draft": False, "prerelease": False, "tag_name": "v2.10.0"},
+    }
+    path = tmp_path / "event.json"
+    path.write_text(json.dumps(event))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(path))
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "release")
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v2.10.0")
+    monkeypatch.setenv("GITHUB_SHA", REVISION)
+    monkeypatch.setattr(pub, "run", Mock(return_value=REVISION))
+    return event, path
+
+
+def test_release_validation_checks_tag_commit_and_main_ancestry(release_event):
+    assert pub.release_revision("2.10.0") == REVISION
+    pub.run.assert_any_call("git", "rev-parse", "refs/tags/v2.10.0^{commit}")
+    pub.run.assert_any_call(
+        "git", "merge-base", "--is-ancestor", REVISION, "refs/remotes/origin/main"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"), [("draft", True), ("prerelease", True), ("tag_name", "v2.9.0")]
+)
+def test_invalid_release_metadata_is_refused(release_event, field, value):
+    event, path = release_event
+    event["release"][field] = value
+    path.write_text(json.dumps(event))
+    with pytest.raises(ValueError, match="matching published stable"):
+        pub.release_revision("2.10.0")
+    pub.run.assert_not_called()
+
+
+def test_moved_tag_is_refused(release_event):
+    pub.run.side_effect = [REVISION, "d" * 40]
+    with pytest.raises(ValueError, match="disagree"):
+        pub.release_revision("2.10.0")
+
+
+def test_pr_cannot_enter_publishing_even_if_workflow_gate_is_removed(
+    release_event, monkeypatch
+):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_REPOSITORY", REPOSITORY)
+    monkeypatch.setattr(pub, "source_version", lambda: "2.10.0")
+    registry = Mock()
+    monkeypatch.setattr(pub, "Registry", registry)
+    monkeypatch.setattr(sys, "argv", ["publish_container.py", "publish"])
+    with pytest.raises(ValueError, match="matching published stable"):
+        pub.main()
+    registry.assert_not_called()


### PR DESCRIPTION
## Feature description

Stable releases publish Python packages, but the existing web-service image has no container publishing channel. This adds public GHCR publication for stable `vX.Y.Z` GitHub Releases, with a `linux/amd64` version image and a `latest` alias for the highest published stable version.

Branch: `feature/ghcr-release`. No linked issue.

## Implementation

- Add a separate container workflow with read-only pull-request and merge-queue smoke checks. Only release jobs receive `packages: write` through `GITHUB_TOKEN`.
- Select Python 3.12 explicitly through uv in all three container jobs; pin the new setup actions to their verified commit SHA.
- Validate release metadata, the tag/event/checkout commit, main ancestry, and the package/lockfile version before publishing.
- Build and smoke-test once. Bind publication to Buildx's configuration digest, accommodating both classic and containerd Docker image stores. Existing versions are verified and reused, never rebuilt or overwritten.
- Reconcile `latest` in a serialized job that selects the highest published stable version, including versions whose pending promotion GitHub replaced. Copy the exact manifest bytes and reject regressions or conflicts.
- Handle GHCR content negotiation explicitly: accept image indexes during lookup so an occupied incompatible tag cannot be mistaken for an absent tag. Drop registry credentials on signed blob redirects.
- Validate image configuration objects and labels before use, with explicit errors for malformed registry metadata.
- Run the EditorConfig CI check from the locked development tools, matching local hooks. The previous action's floating downloader fails against the renamed upstream v4 binaries.
- Update the release title and README, release, post-init, and agent documentation. Scope: 9 files, including the publishing helper, behavioral tests, and EditorConfig CI repair.

## Testing performed

- `just setup` and `just check`: 312 tests passed; 4 slow/live tests excluded by the repository default. Existing deprecation/YAML warnings remain.
- 32 targeted behavioral tests for release guards, retries, conflicts, promotion, content negotiation, digest identity, and anonymous credential isolation.
- Ruff, helper type checking, actionlint, and YAML validation passed.
- `uv run press verify` passed over its scanned set, with the repository's existing lockfile and snapshot regeneration exemptions.
- Built and ran the actual image: `/healthz` reported the expected version and the container ran as UID 999. A wrong expected version was rejected.
- Disposable local registry: real first push, replay with rebuilding disabled, identical replay digest, exact-byte `latest` promotion, anonymous pull, and conflict refusal all passed. The registry container and its volume were removed.
- Read-only probes against live GHCR verified manifest/config digests, blob redirects, missing-tag classification, and occupied-index refusal.
- Review probes reproduced the older-Python import failure and malformed-config exceptions. Python 3.12 selection and explicit metadata validation passed, including a valid-label control.
- The health-probe string satisfies the 88-character source limit; an AST comparison confirmed its executable content is unchanged.
- GitHub CI passed at `6e28ed8`. Greptile completed its final review with no outstanding findings. CodeRabbit reviewed the initial implementation; its later automatic review was rate-limited.

## Rollout and limitations

No production image or new release has been published by this change. The first stable release containing the workflow creates the GHCR package. New GHCR packages start private, so the initial anonymous-pull check may fail after upload. Set that package to Public and rerun the failed release job; it reuses the uploaded image. This one-time setup and recovery are documented in `docs/RELEASE.md`.

Actual GitHub Actions token-based GHCR writes and public visibility will be verified at that first release. The existing Dockerfile, application code, and PyPI publishing workflow are unchanged. No breaking application changes.

## Checklist

- [x] Branch name follows the feature convention
- [x] Local required checks and targeted tests passed
- [x] Conventional commit; release-please owns the changelog entry
- [x] Documentation and CI container checks added
- [x] Adversarial plan review completed and findings corrected
- [x] GitHub CI passed on the final revision
