### PR TITLE
ci(bootstrap): exercise generated apps and python 3.14

### DIFF
--- a/.github/workflows/bootstrap-acceptance.yml
+++ b/.github/workflows/bootstrap-acceptance.yml
@@ -1,0 +1,59 @@
+# Blueprint-only acceptance; generation removes this workflow and its tests.
+name: bootstrap-acceptance
+
+on:
+  schedule:
+    - cron: '37 6 * * 3'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/bootstrap-acceptance.yml'
+      - 'tests/bootstrap/**'
+      - 'tests/meta/**'
+      - 'tests/cli/**'
+      - 'src/**'
+      - 'press/**'
+      - 'scripts/**'
+      - 'docs/source/**'
+      - 'docs/PROJECT_SETUP.md'
+      - '.python-version'
+      - '.bun-version'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'package.json'
+      - 'bun.lock'
+      - 'Makefile'
+      - 'Justfile'
+      - 'lefthook.yml'
+      - 'release-please-config.json'
+      - '.release-please-manifest.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bootstrap-acceptance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bootstrap-acceptance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: '3.13'
+      - name: Provision the native toolchain
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.bun/bin:$HOME/.cargo/bin:$PATH"
+          make bootstrap
+          just setup
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.bun/bin"
+            echo "$HOME/.cargo/bin"
+          } >> "$GITHUB_PATH"
+      - name: Generate and exercise a fresh application
+        run: uv run --locked --extra web pytest tests/bootstrap -m live -s

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false  # report all selected Python versions
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,10 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python-version: ["3.13"]
+        # Runtime coverage on Linux; 3.13 retains the full platform matrix.
+        include:
+          - os: ubuntu
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v7
       - name: Install uv

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.configuration.outputs.configured == 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.214
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.214
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/Justfile
+++ b/Justfile
@@ -464,7 +464,7 @@ alias contributors := update-contributors
 
 [group('build')]
 update-contributors:
-    npx {{contributors_package}} init --non-interactive --owner {{contributors_owner}} --repo {{repo_name}} --config-file .contributors.yml
+    bun x --bun {{contributors_package}} init --non-interactive --owner {{contributors_owner}} --repo {{repo_name}} --config-file .contributors.yml
 
 # Verify commit messages follow conventional commit format (commitlint per ADR-04).
 [group('hooks')]

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -28,7 +28,7 @@ file by hand — see Conventions.
 | P04 | `[x]` | [Py-API Boundary Validation](projects/P04-py-api-boundary-validation.md) — validate Py-API responses at the edge with Pydantic; silent drift → APIError |
 | P05 | `[x]` | [Template-press v3.4 dogfood & conform](projects/P05-template-press-v34-dogfood-conform.md) — press/ config from scratch, verify to declarations-only green, rebrand + publish an instance; findings → Run 4 PROBLEM-NN |
 | P06 | `[x]` | [Full conform — retire the embedded engine](projects/P06-full-conform.md) — delete init/, CI cutover to press verify, v3.6.0 config upgrade ([[remove]], verify_exempt, scan=boundary); closes #423 |
-| P07 | `[~]` | [Template Press upgrade and Python 3.13 bootstrap](projects/P07-press-upgrade-and-python-313.md) — adopt the released press and prove a usable generated project |
+| P07 | `[x]` | [Template Press upgrade and Python 3.13 bootstrap](projects/P07-press-upgrade-and-python-313.md) — adopt the released press and prove a usable generated project |
 
 ## Conventions
 

--- a/docs/source/about/design_decisions.md
+++ b/docs/source/about/design_decisions.md
@@ -838,13 +838,15 @@ CLA.
 **Refs** — `docs/source/contributing/cla/`,
 [CLA tool guide](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/source/tools/cla-assistant.md).
 
-### Automated contributor recognition
-**What** — a weekly workflow runs `contributors-please` to update the contributor
-list.
-**Why** — recognizing contributors manually is forgotten; automating it ensures
-nobody is missed.
-**Value** — every participant is acknowledged, automatically.
-**Refs** — `.github/workflows/update-contributors.yml`.
+### Optional contributor recognition
+**What** — the source blueprint uses `contributors-please` after pushes to
+`main` or manual workflow dispatch. Generated applications remove the roster,
+state and update workflow, while retaining an optional local helper.
+**Why** — an application should choose its contributor policy and configure its
+own automation rather than inherit the blueprint's records and credentials.
+**Value** — fresh applications work without contributor-service configuration;
+maintainers can opt in with `just contributors`.
+**Refs** — [contributor tracking](../contributing/index.md#tracking-contributors).
 
 ---
 

--- a/docs/source/about/design_decisions.md
+++ b/docs/source/about/design_decisions.md
@@ -52,10 +52,13 @@ the project and its development tools keeps setup, hooks and CI compatible.
 behaviour that only reproduces on an old interpreter.
 **Refs** — `pyproject.toml [project]`, `.python-version`; ITM-033.
 
-### Tested on 3.13
-**What** — the CI test matrix runs Python 3.13 on Linux, macOS and Windows.
-**Why** — test the supported minimum on each platform the template advertises.
-**Value** — generated projects inherit checks for the same runtime as setup.
+### Tested on Python 3.13 and 3.14
+**What** — CI tests Python 3.13 on Linux, macOS and Windows, plus Python 3.14
+on Linux. Python 3.13 remains the minimum and setup default.
+**Why** — cover the supported minimum on every platform and check the newer
+interpreter without duplicating the entire platform matrix.
+**Value** — generated projects inherit both minimum-version and newer-runtime
+coverage.
 **Refs** — `.github/workflows/ci.yml`; ITM-030.
 
 ---
@@ -340,7 +343,8 @@ verifying the API matches its own schema.
 **Refs** — `tests/web/`, `pyproject.toml`; WEB-50.
 
 ### Cross-platform, cross-version matrix
-**What** — CI runs the suite on ubuntu/macOS/windows × Python 3.13.
+**What** — CI runs the suite on Linux, macOS and Windows with Python 3.13,
+plus a Linux/Python 3.14 job.
 **Why** — a template is cloned everywhere; path handling, line endings, and
 interpreter quirks must be proven across OSes and versions.
 **Value** — broad compatibility is evidence-backed.

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -51,10 +51,10 @@ To opt in locally, run the retained helper from the repository root:
 just contributors
 ```
 
-The helper initializes contributor state when needed, updates it from Git history,
-and renders `CONTRIBUTORS.md`. An existing `.contributors.yml` is not required;
-identity-map configuration is optional. This command does not install a workflow
-or configure GitHub credentials.
+The helper uses Bun from `just setup`. It initializes contributor state when
+needed, updates it from Git history, and renders `CONTRIBUTORS.md`. An existing
+`.contributors.yml` is not required; identity-map configuration is optional. This
+command does not install a workflow or configure GitHub credentials.
 
 The source blueprint maintains its roster with a workflow triggered by pushes
 to `main` and manual dispatch. Generated applications must deliberately install

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -40,23 +40,28 @@ Before your contributions can be accepted, you must sign a **Contributor License
 When you open a pull request, the **CLA Assistant Bot** will check if you've signed the CLA. If not, it will provide a link to complete the process.
 
 ## Tracking Contributors
-This project uses [`contributors-please`](https://github.com/smorinlabs/contributors-please-action) to track contributors automatically in [`CONTRIBUTORS.md`](https://github.com/smorinlabs/py-launch-blueprint/blob/main/CONTRIBUTORS.md). The list updates when:
-1. A push is made to the main branch.
-2. A pull request is merged.
-3. Manually, using the following command:
-   ```bash
-   just contributors
-   ```
 
-### How Contributors are Tracked
+Contributor automation is optional. A generated application starts without
+`CONTRIBUTORS.md`, `.contributors.yml`, `.contributors.jsonl` or the
+`update-contributors.yml` workflow. Its Git history still records contributions.
 
-Contributors are tracked based on git commit history. The system:
-- Counts commits per contributor
-- Shows contribution statistics
-- Joins commit authors to GitHub logins using no-reply addresses and `.contributors.yml`
-- Sorts contributors by number of commits
+To opt in locally, run the retained helper from the repository root:
 
-For more details, see the [contributors-please action](https://github.com/smorinlabs/contributors-please-action).
+```bash
+just contributors
+```
+
+The helper initializes contributor state when needed, updates it from Git history,
+and renders `CONTRIBUTORS.md`. An existing `.contributors.yml` is not required;
+identity-map configuration is optional. This command does not install a workflow
+or configure GitHub credentials.
+
+The source blueprint maintains its roster with a workflow triggered by pushes
+to `main` and manual dispatch. Generated applications must deliberately install
+and configure automation if they want the same behavior. See
+[project setup](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/PROJECT_SETUP.md)
+for optional service configuration.
+
 ## Code of Conduct
 We are committed to fostering a **welcoming and inclusive** community. Please review and adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/docs/source/reference/cli_reference.md
+++ b/docs/source/reference/cli_reference.md
@@ -163,7 +163,11 @@ just pre-commit-run
 ```
 
 ### `contributors`
-Update `CONTRIBUTORS.md` file.
+
+Opt in to local contributor tracking. Initialize state when absent, update it
+from Git history, and render `CONTRIBUTORS.md`. Generated applications do not
+include a roster or automatic update workflow by default. This helper does not
+enable GitHub automation; see [contributor tracking](../contributing/index.md#tracking-contributors).
 
 #### Usage
 ```bash

--- a/docs/source/reference/project_structure.md
+++ b/docs/source/reference/project_structure.md
@@ -82,7 +82,7 @@ py-launch-blueprint/
 │   ├── core/                       # Library: logic + Pydantic models
 │   └── web/                        # FastAPI web service (behind the `web` extra)
 ├── pyproject.toml                  # Project configuration file
-├── CONTRIBUTORS.md                 # Project contributors
+├── CONTRIBUTORS.md                 # Optional: created by contributor tooling
 ├── README.md                       # Project overview and navigation
 ├── SECURITY.md                     # Security policy
 └── tests/                          # Test files
@@ -166,7 +166,10 @@ Template for pull requests to ensure consistency and completeness.
 Configuration file for the project, including dependencies and build settings.
 
 ### CONTRIBUTORS.md
-Auto-generated file that lists the project contributors.
+
+Optional contributor roster. Generation removes the blueprint roster and its
+automation state. Running `just contributors` explicitly creates a project-local
+roster; see [contributor tracking](../contributing/index.md#tracking-contributors).
 
 ### README.md
 

--- a/docs/source/tasks/contributing_code.md
+++ b/docs/source/tasks/contributing_code.md
@@ -86,8 +86,11 @@ for more information, see the [Contributor License Agreement](../contributing/in
 
 ## Contributors
 
-This project includes a `just contributors` helper that invokes
-`contributors-please` to bootstrap or refresh the local contributors list.
+Contributor automation is optional. Generated applications start without the
+blueprint roster, state files or update workflow. The retained `just contributors`
+helper initializes or refreshes a local roster when explicitly requested. It
+does not enable a GitHub workflow. See
+[contributor tracking](../contributing/index.md#tracking-contributors).
 
 ### Manual Update
 

--- a/docs/source/tasks/using_ci_cd.md
+++ b/docs/source/tasks/using_ci_cd.md
@@ -1,66 +1,85 @@
-# **CI/CD with GitHub Actions**
+# CI/CD with GitHub Actions
 
-This guide explains how to automate testing, linting, and deployment for the Py Launch Blueprint project using GitHub Actions. [Learn more](../tools/github_actions.md).
+The checked-in workflows are the source of truth. CI validates the project;
+release workflows publish only after their separate release triggers and setup.
 
-## **Workflow Overview**
+## Pull-request and merge checks
 
-The CI/CD workflow (`.github/workflows/ci.yaml`) runs on:
-- Pushes to `main`
-- Pull requests targeting `main`
+The main workflow is `.github/workflows/ci.yml`. It runs for pull requests to
+`main`, pushes to `main`, and the merge queue's `merge_group` event.
 
-### **Jobs**
-- **Test**: Runs tests on Python 3.13 (ubuntu + macOS matrix)
-  - Sets up environment using `uv` and `actions/setup-python`
-  - Installs dependencies: `uv sync --all-extras --dev`
-  - Runs ty (`uv run ty check`), Ruff (`uvx ruff check`), and pytest (`uvx pytest`)
+| Check | What it validates |
+|---|---|
+| `changes` | Detects code and packaging changes; documentation-only pull requests can skip the heavier jobs. |
+| `lint` | Ruff lint and formatting checks using locked development tools. |
+| `typecheck` | Types under `src/py_launch_blueprint/`, with the web extra installed. |
+| `import-boundaries` | Import and module boundaries through import-linter and Tach. |
+| `test` | Python 3.13 on Linux, macOS and Windows; Python 3.14 on Linux. Includes slow tests and excludes provisioned live tests. |
+| `build-smoke` | Builds wheel and source archives, checks metadata, installs both and runs the CLI. |
+| `docs` | Builds Sphinx documentation with warnings treated as errors. |
+| `toml-format-check` | Checks TOML formatting. |
+| `ci-ok` | Aggregates the preceding jobs for branch protection. A failed prerequisite cannot produce a successful aggregate. |
 
-## **Workflow Configuration**
+Coverage is collected and uploaded from the Linux/Python 3.13 test job.
+Other test jobs validate runtime compatibility without uploading duplicate coverage.
+Python 3.13 remains the minimum supported version and default development interpreter.
 
-```yaml
-name: CI/CD
+`.github/workflows/lint.yml` adds Actionlint, Bandit, spelling, EditorConfig
+and YAML checks. Other workflows handle press conformance, secret scanning,
+dependency review, CodeQL and container checks. Required check names come from
+GitHub branch protection and repository rules; keep those rules aligned when
+renaming or removing jobs.
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+## Reproduce the checks locally
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.13"]
+Run these commands from the repository root:
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv sync --all-extras --dev
-      - run: uv run ty check src/py_launch_blueprint/
-      - run: uvx ruff check py_launch_blueprint/
-      - run: uvx pytest
+```bash
+just setup
+just check
+uv run --locked press verify
 ```
 
-## **Customization**
+`just setup` installs the native tools, locked development/web dependencies and
+Lefthook hooks. See [Setting Up Development](setting_up_development.md) for
+fresh-machine setup.
 
-- **Add more Python versions**:
-  ```yaml
-  strategy:
-    matrix:
-      python-version: ["3.13"]
-  ```
-- **Add security scanning**:
-  ```yaml
-  - name: Run security scan
-    run: uvx bandit -r py_launch_blueprint/
-  ```
-- **Cache dependencies**:
-  ```yaml
-  - uses: actions/cache@v3
-    with:
-      path: .venv
-      key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
-  ```
+To reproduce a CI test job, select its Python version and include slow tests:
+
+```bash
+uv sync --locked --python 3.14 --group dev --extra web
+uv run --no-sync pytest -m "not live" -n auto
+```
+
+Use `3.13` instead to reproduce the minimum-version job. `--locked` requires the
+committed dependency resolution; `--no-sync` then uses that prepared environment.
+This switches the local environment's interpreter. Run `just setup` afterward
+to restore the default selected by `.python-version`.
+
+## Scheduled dependency checks
+
+`.github/workflows/canary.yml` runs weekly and supports manual dispatch. It
+tests Python 3.13 and 3.14 against newly resolved allowed dependency versions.
+Its `uv sync --upgrade` is intentional: ordinary PR CI uses the lock, while
+the canary detects future dependency incompatibilities. The canary is not a
+required PR check and does not commit its temporary lock changes.
+
+## Blueprint generation acceptance
+
+Before rebranding, `.github/workflows/bootstrap-acceptance.yml` provisions the
+native toolchain and runs `tests/bootstrap` weekly, on manual dispatch, and
+for pull requests changing bootstrap-related files. It generates a fresh
+application, runs its setup and checks, builds documentation and distributions,
+and exercises its CLI and web health endpoint. It creates no GitHub repository
+and publishes nothing. Generic CI continues to exclude these live tests.
+
+Generation removes this blueprint-only workflow and its tests. Application
+maintainers should add acceptance tests for their own application behavior.
+
+## Releases
+
+`.github/workflows/release-please.yml` prepares release PRs after pushes to
+`main`. Tagged releases trigger `publish.yml`, which publishes to TestPyPI
+before PyPI. `publish-container.yml` checks containers on PRs and publishes
+stable release images separately. Configure the required services before the
+first release; see [release instructions](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/RELEASE.md).

--- a/docs/source/tools/github_actions.md
+++ b/docs/source/tools/github_actions.md
@@ -1,46 +1,30 @@
 # GitHub Actions
 
-## Setup
+GitHub Actions runs automated checks and release workflows for Py Launch Blueprint.
+The checked-in configuration lives in
+[`.github/workflows/`](https://github.com/smorinlabs/py-launch-blueprint/tree/main/.github/workflows).
 
-GitHub Actions automates testing and deployment. The Py Launch Blueprint project includes a pre-configured workflows in [`.github/workflows/`](https://github.com/smorinlabs/py-launch-blueprint/tree/main/.github/workflows).
+## Workflow configuration
 
-## Workflow Configuration
+The main workflow is
+[`ci.yml`](https://github.com/smorinlabs/py-launch-blueprint/blob/main/.github/workflows/ci.yml).
+It runs for pushes to `main`, pull requests targeting `main`, and merge-queue
+validation through the `merge_group` event.
 
-The workflow runs on every push or pull request to `main`:
+The test matrix covers these combinations:
 
-```yaml
-name: CI/CD
+| Python version | Platforms |
+|---|---|
+| 3.13 | Linux, macOS and Windows |
+| 3.14 | Linux |
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+Python 3.13 remains the minimum and setup default. Pull-request CI uses the
+committed dependency lock; the separate weekly dependency canary tests both
+Python versions with the latest allowed dependencies.
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.13"]
+The main workflow also checks lint, types, import boundaries, package builds,
+documentation and TOML formatting. Its `ci-ok` job reports the aggregate result.
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: uv sync --all-extras --dev
-      - run: uv run ty check src/py_launch_blueprint/
-      - run: uvx ruff check py_launch_blueprint/
-```
-
-## Best Practices
-
-- **Keep It Simple**: Start small and expand as needed.
-- **Use Matrix Builds**: Test across multiple Python versions.
-- **Cache Dependencies**: Speed up workflows by caching dependencies.
-- **Fail Fast**: Identify and fix issues quickly.
-- **Monitor Regularly**: Ensure workflows run efficiently.
-
-[Actions documentation](https://docs.github.com/en/actions) for more details.
+For exact local commands, job conditions, the canary and release workflows, see
+[Using CI/CD](../tasks/using_ci_cd.md). Use the checked-in workflows as the source
+for executable configuration.

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,6 @@ behind the `web` extra — every front-end renders the same result models.
 
 ## Optional
 
-- [Contributing](https://github.com/smorinlabs/py-launch-blueprint/blob/main/CONTRIBUTORS.md): contributor list and workflow
+- [Contributing](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/source/contributing/index.md): contribution guide and optional contributor tracking
 - [Release process](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/RELEASE.md): release-please + OIDC trusted publishing
 - [Project setup](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/PROJECT_SETUP.md): development setup and optional repository and service configuration after rebranding

--- a/press/press-rules.toml
+++ b/press/press-rules.toml
@@ -160,6 +160,10 @@ file = "tests/meta/test_bootstrap_skill.py"
 reason = "template bootstrap skill and its dedicated contract test"
 
 [[remove]]
+file = ".github/workflows/bootstrap-acceptance.yml"
+reason = "blueprint acceptance workflow; its tests are removed from applications"
+
+[[remove]]
 dir = "tests/bootstrap"
 reason = "template acceptance tests generate a new project and must not recurse"
 

--- a/projects/P07-press-upgrade-and-python-313.md
+++ b/projects/P07-press-upgrade-and-python-313.md
@@ -10,7 +10,7 @@ Adopt the released press and prove a usable generated project.
 - **Release:** [Template Press 4.1.0](https://github.com/smorinlabs/template-press/releases/tag/v4.1.0)
 - **Dependency gate:** [Template Press PR #131](https://github.com/smorinlabs/template-press/pull/131)
 
-**Status:** `[~]` implementation delivered in [PR #530](https://github.com/smorinlabs/py-launch-blueprint/pull/530); deferred review follow-ups remain. Merge and release are outside the implementation tasks.
+**Status:** `[~]` bootstrap upgrade delivered in [PR #530](https://github.com/smorinlabs/py-launch-blueprint/pull/530); T06–T09 implemented on `ci/p07-bootstrap-followups`; T10 remains deferred. Merge and release are outside the implementation tasks.
 
 ### Scope
 
@@ -36,19 +36,51 @@ will be recorded separately from blueprint fixes.
 - [x] [P07-T03] Update bootstrap instructions, generated docs, and first-PR CI.
 - [x] [P07-T04] Pass source checks, then bootstrap and exercise a generated project.
 - [x] [P07-T05] Commit and prepare the delivery PR with exact validation evidence.
-- [ ] [P07-T06] Add provisioned scheduled or manually dispatched bootstrap acceptance CI. Deferred from [review 3986130902](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130902); requires the native toolchain and network, and remains separate from generic CI's deliberate live-test exclusion.
-- [ ] [P07-T07] Evaluate and add Python 3.14 CI/canary coverage alongside the 3.13 minimum. Deferred from [review 3986130907](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130907); Python 3.14 lock resolution and the coverage gap already existed before this PR.
-- [ ] [P07-T08] Refresh the retained CI tutorial against actual workflow commands and supported platforms. Deferred from [review 3986130826](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130826); the Ubuntu-only example, macOS prose, wrong workflow extension, and floating tool examples predate this PR.
-- [ ] [P07-T09] Correct retained generated documentation for optional contributor automation. Deferred from [Copilot review 5175179607](https://github.com/smorinlabs/py-launch-blueprint/pull/530#pullrequestreview-5175179607); Sphinx pages advertise the removed workflow/roster. The separate claim that initialization requires an existing `.contributors.yml` was refuted against published contributors-please 1.4.3: `init` uses defaults when the file is absent. Verify generated links without enabling external automation.
+- [x] [P07-T06] Add provisioned scheduled or manually dispatched bootstrap acceptance CI. Deferred from [review 3986130902](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130902); requires the native toolchain and network, and remains separate from generic CI's deliberate live-test exclusion.
+- [x] [P07-T07] Evaluate and add Python 3.14 CI/canary coverage alongside the 3.13 minimum. Deferred from [review 3986130907](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130907); Python 3.14 lock resolution and the coverage gap already existed before this PR.
+- [x] [P07-T08] Refresh the retained CI tutorial against actual workflow commands and supported platforms. Deferred from [review 3986130826](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130826); the Ubuntu-only example, macOS prose, wrong workflow extension, and floating tool examples predate this PR.
+- [x] [P07-T09] Correct retained generated documentation for optional contributor automation. Deferred from [Copilot review 5175179607](https://github.com/smorinlabs/py-launch-blueprint/pull/530#pullrequestreview-5175179607); Sphinx pages advertise the removed workflow/roster. The separate claim that initialization requires an existing `.contributors.yml` was refuted against published contributors-please 1.4.3: `init` uses defaults when the file is absent. Verify generated links without enabling external automation.
 - [ ] [P07-T10] Pin the Claude review action to a verified immutable commit and confirm Dependabot maintains the pin. Deferred from [review 3995193747](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3995193747); `anthropics/claude-code-action@v1.0.214` and its credential/OIDC permissions are unchanged from base `e3ed657`. Keep this supply-chain hardening separate from the bootstrap upgrade, preserve the action version and credential-gated behavior, and validate the workflow and configured/missing-secret paths.
 
-Tasks P07-T06 through P07-T09 are tracked follow-ups, not merge requirements
-for the Python 3.13 / Template Press 4.1.0 upgrade. The delivered implementation
-tasks above remain complete; the trunk stays open to keep follow-ups visible.
-The owner reaffirmed on 2026-09-11 that these four items belong in a separate
-CI and documentation follow-up, after the two approved bootstrap fixes.
-P07-T10 records a later review suggestion for separate CI hardening; it does
-not alter the four owner-agreed follow-ups or add a bootstrap merge requirement.
+### Follow-up recommendation and delivery
+
+The owner delegated reassessment and implementation of the recommended P07
+follow-ups. T06 through T09 are worth fixing now because they close missing
+regression coverage or correct instructions that users encounter.
+
+| Item | Decision | Delivered scope |
+|---|---|---|
+| P07-T06 | Implement | A dedicated weekly/manual/bootstrap-path PR workflow provisions the native toolchain and exercises the existing live generation test. Generation removes this workflow with its tests. |
+| P07-T07 | Implement with limited extra CI | Add Linux/Python 3.14 to the normal test matrix and 3.14 to the weekly dependency canary. Keep Python 3.13 as the minimum and preserve its Linux/macOS/Windows coverage. |
+| P07-T08 | Implement | Replace the obsolete CI example with the real workflow paths, triggers, jobs, locked commands and separate release/acceptance behavior. |
+| P07-T09 | Implement | Document contributor tracking as an explicit opt-in for generated applications; remove links and claims that assume the retired roster/workflow exists. |
+| P07-T10 | Defer | Reassess immutable action pins as a consistent workflow policy with an explicit vulnerability-alert strategy, rather than changing one inherited Claude reference in this bootstrap follow-up. |
+
+GitHub recommends commit pins for immutability, and Dependabot version updates
+support them. However, GitHub currently documents that Dependabot vulnerability
+alerts for Actions require semantic versions and do not cover SHA references.
+That makes T10 a policy tradeoff, not a bootstrap correctness fix. Keep the
+existing credential switch and action reference for now. Revisit when adopting
+consistent action pinning and deciding how to retain vulnerability monitoring.
+Sources: [secure use](https://docs.github.com/en/actions/reference/security/secure-use),
+[Dependabot alert limitations](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-alerts),
+[version-update support](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories).
+
+Implementation commit `204961118e208969b751bb4644a76570c28938bc` passed source
+checks (327 tests, 11 snapshots), Actionlint, Sphinx with warnings as errors,
+and the full generated-application acceptance in 71.54 seconds (321 tests,
+11 snapshots, setup/check, press verification, documentation, wheel/sdist,
+CLI and real HTTP health). The exact Python 3.14 CI test command also passed
+331 tests and 11 snapshots on macOS; three native PowerShell cases skip there.
+GitHub runner execution is recorded on the follow-up PR. Scheduled/manual
+triggers become available after the workflow lands on the default branch.
+
+The additional normal CI runtime cell is Linux-only: the prior PR's three
+Python 3.13 test jobs took 20, 17 and 24 seconds on Linux, macOS and Windows,
+respectively. This change adds one runtime cell instead of doubling all three
+platforms. These observations are not an estimate of future hosted CI cost.
+T10 remains open, so P07 stays in progress. The original bootstrap upgrade
+remains on PR #530; this follow-up does not authorize either PR's merge.
 
 ### Notes
 

--- a/projects/P07-press-upgrade-and-python-313.md
+++ b/projects/P07-press-upgrade-and-python-313.md
@@ -10,7 +10,7 @@ Adopt the released press and prove a usable generated project.
 - **Release:** [Template Press 4.1.0](https://github.com/smorinlabs/template-press/releases/tag/v4.1.0)
 - **Dependency gate:** [Template Press PR #131](https://github.com/smorinlabs/template-press/pull/131)
 
-**Status:** `[~]` bootstrap upgrade delivered in [PR #530](https://github.com/smorinlabs/py-launch-blueprint/pull/530); T06–T09 implemented on `ci/p07-bootstrap-followups`; T10 remains deferred. Merge and release are outside the implementation tasks.
+**Status:** `[x]` implementation complete in [PR #530](https://github.com/smorinlabs/py-launch-blueprint/pull/530) and [PR #532](https://github.com/smorinlabs/py-launch-blueprint/pull/532). T06–T10 are implemented on `ci/p07-bootstrap-followups`. Merge and release are outside the implementation tasks.
 
 ### Scope
 
@@ -40,7 +40,7 @@ will be recorded separately from blueprint fixes.
 - [x] [P07-T07] Evaluate and add Python 3.14 CI/canary coverage alongside the 3.13 minimum. Deferred from [review 3986130907](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130907); Python 3.14 lock resolution and the coverage gap already existed before this PR.
 - [x] [P07-T08] Refresh the retained CI tutorial against actual workflow commands and supported platforms. Deferred from [review 3986130826](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3986130826); the Ubuntu-only example, macOS prose, wrong workflow extension, and floating tool examples predate this PR.
 - [x] [P07-T09] Correct retained generated documentation for optional contributor automation. Deferred from [Copilot review 5175179607](https://github.com/smorinlabs/py-launch-blueprint/pull/530#pullrequestreview-5175179607); Sphinx pages advertise the removed workflow/roster. The separate claim that initialization requires an existing `.contributors.yml` was refuted against published contributors-please 1.4.3: `init` uses defaults when the file is absent. Verify generated links without enabling external automation.
-- [ ] [P07-T10] Pin the Claude review action to a verified immutable commit and confirm Dependabot maintains the pin. Deferred from [review 3995193747](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3995193747); `anthropics/claude-code-action@v1.0.214` and its credential/OIDC permissions are unchanged from base `e3ed657`. Keep this supply-chain hardening separate from the bootstrap upgrade, preserve the action version and credential-gated behavior, and validate the workflow and configured/missing-secret paths.
+- [x] [P07-T10] Use `anthropics/claude-code-action@v1` in both Claude workflows. The owner selected the maintained major-version tag on 2026-09-12, replacing the immutable-commit proposal from [review 3995193747](https://github.com/smorinlabs/py-launch-blueprint/pull/530#discussion_r3995193747). Preserve the automatic review credential gate and both workflows' permissions; validate workflow syntax and the configured/missing-secret controls.
 
 ### Follow-up recommendation and delivery
 
@@ -54,17 +54,16 @@ regression coverage or correct instructions that users encounter.
 | P07-T07 | Implement with limited extra CI | Add Linux/Python 3.14 to the normal test matrix and 3.14 to the weekly dependency canary. Keep Python 3.13 as the minimum and preserve its Linux/macOS/Windows coverage. |
 | P07-T08 | Implement | Replace the obsolete CI example with the real workflow paths, triggers, jobs, locked commands and separate release/acceptance behavior. |
 | P07-T09 | Implement | Document contributor tracking as an explicit opt-in for generated applications; remove links and claims that assume the retired roster/workflow exists. |
-| P07-T10 | Defer | Reassess immutable action pins as a consistent workflow policy with an explicit vulnerability-alert strategy, rather than changing one inherited Claude reference in this bootstrap follow-up. |
+| P07-T10 | Implement owner-selected major tag | Use `anthropics/claude-code-action@v1` in the automatic review and interactive Claude workflows, retaining their existing configuration and permissions. |
 
-GitHub recommends commit pins for immutability, and Dependabot version updates
-support them. However, GitHub currently documents that Dependabot vulnerability
-alerts for Actions require semantic versions and do not cover SHA references.
-That makes T10 a policy tradeoff, not a bootstrap correctness fix. Keep the
-existing credential switch and action reference for now. Revisit when adopting
-consistent action pinning and deciding how to retain vulnerability monitoring.
-Sources: [secure use](https://docs.github.com/en/actions/reference/security/secure-use),
-[Dependabot alert limitations](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-alerts),
-[version-update support](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories).
+The owner resolved T10 on 2026-09-12: follow the maintained `v1` tag and
+receive updates within major version 1. A future major version requires an
+explicit workflow-reference change. The earlier SHA-pinning proposal is closed
+by this decision, with no deferred pinning requirement. The automatic review
+still uses `CLAUDE_CODE_OAUTH_TOKEN` as its single configuration switch and
+reports a successful skip when that secret is absent. Sources: Anthropic
+[documented usage](https://github.com/anthropics/claude-code-action/releases/tag/v1)
+and [major-tag release automation](https://github.com/anthropics/claude-code-action/blob/main/.github/workflows/release.yml).
 
 Implementation commit `204961118e208969b751bb4644a76570c28938bc` passed source
 checks (327 tests, 11 snapshots), Actionlint, Sphinx with warnings as errors,
@@ -79,8 +78,9 @@ The additional normal CI runtime cell is Linux-only: the prior PR's three
 Python 3.13 test jobs took 20, 17 and 24 seconds on Linux, macOS and Windows,
 respectively. This change adds one runtime cell instead of doubling all three
 platforms. These observations are not an estimate of future hosted CI cost.
-T10 remains open, so P07 stays in progress. The original bootstrap upgrade
-remains on PR #530; this follow-up does not authorize either PR's merge.
+All P07 implementation tasks are complete with the owner-approved T10
+decision. The original bootstrap upgrade remains on PR #530, and the
+follow-ups are on PR #532. Merge and publication remain separate from delivery.
 
 ### Notes
 

--- a/tests/bootstrap/test_template_press.py
+++ b/tests/bootstrap/test_template_press.py
@@ -177,6 +177,11 @@ def test_committed_blueprint_generates_a_usable_project(tmp_path):
         "prototypes/press_tui",
         ".claude/skills/new-python-project/SKILL.md",
         "tests/bootstrap",
+        ".github/workflows/bootstrap-acceptance.yml",
+        ".github/workflows/update-contributors.yml",
+        "CONTRIBUTORS.md",
+        ".contributors.yml",
+        ".contributors.jsonl",
         "tests/meta/test_bootstrap_skill.py",
     ):
         assert not (target / removed).exists(), removed
@@ -198,6 +203,11 @@ def test_committed_blueprint_generates_a_usable_project(tmp_path):
     for pointer in ("README.md", "docs/POST_INIT.md"):
         assert "PROJECT_SETUP.md" in (target / pointer).read_text()
     assert (target / "docs/PROJECT_SETUP.md").is_file()
+    contributor_guide = (target / "docs/source/contributing/index.md").read_text()
+    assert "Contributor automation is optional." in contributor_guide
+    assert "just contributors" in contributor_guide
+    assert "/blob/main/CONTRIBUTORS.md)" not in contributor_guide
+    assert "does not install a workflow" in contributor_guide
     design = (target / "docs/source/about/design_decisions.md").read_text()
     assert "Rebranding retires the executable skill" in design
     assert ".claude/skills/new-python-project/SKILL.md" not in design

--- a/tests/bootstrap/test_template_press.py
+++ b/tests/bootstrap/test_template_press.py
@@ -208,6 +208,13 @@ def test_committed_blueprint_generates_a_usable_project(tmp_path):
     assert "just contributors" in contributor_guide
     assert "/blob/main/CONTRIBUTORS.md)" not in contributor_guide
     assert "does not install a workflow" in contributor_guide
+    llms = (target / "llms.txt").read_text()
+    contributor_url = (
+        f"https://github.com/{IDENTITY['owner']}/{IDENTITY['repo_name']}"
+        "/blob/main/docs/source/contributing/index.md"
+    )
+    assert f"]({contributor_url})" in llms
+    assert "/blob/main/CONTRIBUTORS.md)" not in llms
     design = (target / "docs/source/about/design_decisions.md").read_text()
     assert "Rebranding retires the executable skill" in design
     assert ".claude/skills/new-python-project/SKILL.md" not in design

--- a/tests/meta/test_justfile.py
+++ b/tests/meta/test_justfile.py
@@ -21,5 +21,5 @@ def test_contributors_recipe_runs_contributors_please() -> None:
     )
 
     output = result.stdout + result.stderr
-    assert "npx contributors-please@1 init" in output
+    assert "bun x --bun contributors-please@1 init" in output
     assert "--config-file .contributors.yml" in output


### PR DESCRIPTION
Fresh-application generation now has recurring acceptance coverage, Python 3.14 has a Linux runtime check, and the retained CI/contributor guides describe the behavior that actually ships. Both Claude workflows follow the maintained `v1` action tag.

PR #530 merged as `5b7dfe57d43cd3735634e2684207d91c4b17cb7e`. This PR now targets `main`; branch update `84ef7c852aa6ad31c37ea0e13f4e4dd429775203` preserves the exact reviewed file tree while triggering ordinary main-target CI.

## Recommendations and changes

- **P07-T06: fix.** Add a dedicated weekly/manual/bootstrap-path PR workflow that provisions the native toolchain and generates, checks, builds and runs a fresh application. Remove the workflow during generation with its blueprint-only tests. Generic CI still excludes live tests.
- **P07-T07: fix with a small matrix expansion.** Retain Python 3.13 on Linux/macOS/Windows and add Python 3.14 on Linux. The weekly latest-dependency canary tests both versions. Python 3.13 remains the minimum/default; coverage upload remains on Linux/3.13.
- **P07-T08: fix.** Replace the obsolete CI tutorial with actual workflow paths, triggers, jobs, locked commands, canary behavior and publication boundaries.
- **P07-T09: fix.** Make contributor automation explicitly optional in retained docs, point llms.txt to the retained contributor guide, and explain what the retained local helper does. Run that helper with `bun x --bun` from the canonical toolchain. Generation acceptance checks removal of the inherited roster/state/workflow and validates the rewritten guide link.
- **P07-T10: implemented with the selected major-version policy.** Use `anthropics/claude-code-action@v1` in both Claude workflows. The maintained major tag receives version 1 updates automatically, while a future major version requires an explicit reference change. This replaces the proposed SHA pin and closes T10. The automatic review still uses `CLAUDE_CODE_OAUTH_TOKEN` as its single configuration switch, including the clean missing-secret skip. Workflow permissions are unchanged. All P07 implementation tasks are complete; merge and publication remain separate.

## Validation

CI documentation correction `1360fdb9c78b6af632aaac81acde4dd350e786d8`:

- Corrected both retained guides to show Python 3.13 on Linux/macOS/Windows and Python 3.14 on Linux. Replaced the obsolete duplicated workflow example with links to the checked-in workflow and maintained CI tutorial.
- Source `just check` passed: 327 tests and 11 snapshots. Sphinx `-W` passed, and the rendered pages show the corrected matrix. Commit/pre-push checks, including press verification, passed.
- [GitHub bootstrap acceptance](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34713040390) passed on this head. The [review finding has an evidence reply](https://github.com/smorinlabs/py-launch-blueprint/pull/532#discussion_r3997237513) and is resolved.

Contributor review correction `6c85a57ab47174aaaa9a3bdb71e3615c1a6d9352`:

- Confirmed the retained llms.txt link pointed at a removed file in a generated application. The new acceptance assertions verify the rewritten retained-guide URL and reject the removed roster URL.
- Reproduced `just contributors` failing with `npx: command not found` when only Bun is on PATH. The recipe regression failed before the edit and passes after it. The recipe version smoke and the published contributor CLI's configuration validation both pass under Bun without Node/npm on PATH; authenticated contributor initialization was not performed.
- Source `just check`: 327 tests and 11 snapshots passed. Full committed-source generation acceptance passed in 72.05 seconds, including 321 generated tests, 11 snapshots, docs/build, CLI and real HTTP health. Commit and pre-push checks, including press verification, passed.
- The inline finding has a [verified-fix reply](https://github.com/smorinlabs/py-launch-blueprint/pull/532#discussion_r3997195637) and is resolved. The review-body runner finding has a [separate evidence reply](https://github.com/smorinlabs/py-launch-blueprint/pull/532#issuecomment-5647952571).

T10 commit `5e43951c577a25931ac7acadc8ed9cac25bb1223`:

- `just setup` and `just check` passed: 327 tests and 11 snapshots, including both configured/missing-secret controls; 3 PowerShell cases skipped on macOS and 5 slow/live tests deselected.
- Actionlint, commit hooks and all pre-push checks passed, including Template Press verification of the committed tree.
- The [GitHub Claude workflow](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34710956019) passed with `@v1`; the configured action step ran successfully.
- The [GitHub bootstrap acceptance workflow](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34710956039) passed again on this commit, including generation, setup/check, documentation, package builds, CLI execution and real HTTP health checks.

Implementation commit `204961118e208969b751bb4644a76570c28938bc`:

- Source `just check`: 327 tests and 11 snapshots passed; 3 PowerShell cases skipped on macOS and 5 slow/live tests deselected.
- Python 3.14, exact CI invocation `uv run --no-sync pytest -m "not live" -n auto` after locked sync: 331 tests and 11 snapshots passed; 3 PowerShell cases skipped on macOS.
- Full committed-source generation acceptance: passed in 71.54 seconds. Generated setup/check (321 tests, 11 snapshots), independent press verification, Sphinx `-W`, wheel/sdist, CLI and real HTTP health passed. Confirmed the blueprint acceptance workflow and contributor automation/state are absent from the application.
- Source Sphinx `-W`, Actionlint on all changed workflows, matrix/trigger/permission inspection and commit hooks passed.
- The subsequent tracking-only commit records the recommendation/evidence. Pre-push hooks include source press verification.

GitHub Linux acceptance passed on the earlier PR head `1b67a9606f02e9327770fb18fe09ee80b2a3bc1c`: [workflow run](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34676892933). The runner provisioned the native toolchain and completed the full generation test in 83.87 seconds. The generated application passed 324 tests and 11 snapshots, documentation/build checks, CLI execution and real HTTP health checks on Python 3.13.15. The checkout tested GitHub's synthetic merge commit `6524804d48179430294fbe381257fc45441fab74` against the parent PR branch.

The [ordinary main-target CI run](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34713917828) now includes Linux/Python 3.14, and that job passed on head `84ef7c852aa6ad31c37ea0e13f4e4dd429775203`. Linux/3.13, macOS/3.13, Windows/3.13 and the final ci-ok aggregate also passed. Bootstrap acceptance passed again on this head. Weekly/manual acceptance becomes available when this PR reaches the default branch.

No repository creation, publication, credential changes or downstream application work is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791784652&installation_model_id=425421&pr_number=532&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F532&signature=b5454e728b18414dc7a864576cc10ccb7ebc48728f51831d0f52a1a37c3f4a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->