### PR TITLE
fix: restore dependency canary and update gitpython

### DIFF
--- a/src/py_launch_blueprint/web/middleware.py
+++ b/src/py_launch_blueprint/web/middleware.py
@@ -88,10 +88,15 @@ def _log_access(request: Request, *, status_code: int, start: float) -> None:
     """Emit the one-per-request ``http_request`` event (WEB-12)."""
     if request.url.path in ACCESS_LOG_EXCLUDED_PATHS:
         return
-    # The router sets scope["route"] once matched. Unmatched requests (404s)
-    # log route=None — falling back to the raw path here would let URL spam
-    # blow up the one field kept bounded-cardinality on purpose.
-    matched = request.scope.get("route")
+    # FastAPI >=0.137 preserves the original route without include_router
+    # prefixes. Its request-scoped effective context holds the full template.
+    # This internal metadata has no public request accessor; keep the fallback
+    # for older FastAPI and routes outside an included router.
+    matched = request.scope.get("fastapi", {}).get("effective_route_context")
+    if matched is None:
+        matched = request.scope.get("route")
+    # Unmatched requests log route=None. Never use the raw URL as a fallback:
+    # only route templates keep this field bounded in cardinality.
     log.info(
         "http_request",
         method=request.method,

--- a/tests/web/test_logging.py
+++ b/tests/web/test_logging.py
@@ -9,6 +9,7 @@ import json
 import logging
 
 import pytest
+from fastapi import APIRouter
 from fastapi.testclient import TestClient
 
 from py_launch_blueprint.web.app import create_app
@@ -67,6 +68,49 @@ def test_unmatched_route_logs_none(capsys):
     assert event["route"] is None
     assert event["path"] == "/no/such/route-12345"
     assert event["status"] == 404
+
+
+@pytest.mark.parametrize("root_path", ["", "/gateway"])
+@pytest.mark.parametrize("prefix", ["/v2", "/v3"])
+def test_access_route_preserves_nested_prefixes_and_parameters(
+    capsys, root_path, prefix
+):
+    app = create_app(WebSettings.model_construct(root_path=root_path))
+    items = APIRouter()
+
+    @items.get("/items/{item_id}")
+    async def get_item(tenant_id: str, item_id: str):
+        return {"tenant_id": tenant_id, "item_id": item_id}
+
+    tenants = APIRouter(prefix="/tenants/{tenant_id}")
+    tenants.include_router(items)
+    # The same route can have different effective paths in one application.
+    app.include_router(tenants, prefix="/v2")
+    app.include_router(tenants, prefix="/v3")
+    path = f"{root_path}{prefix}/tenants/acme/items/123"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(path)
+    assert response.status_code == 200
+    (event,) = stderr_events(capsys, "http_request")
+    assert event["route"] == f"{prefix}/tenants/{{tenant_id}}/items/{{item_id}}"
+    assert event["path"] == path
+
+
+def test_access_route_preserves_prefix_on_handler_error(capsys):
+    app = create_app(WebSettings.model_construct())
+    router = APIRouter()
+
+    @router.get("/boom/{item_id}")
+    async def boom(item_id: str):
+        raise RuntimeError("handler failed")
+
+    app.include_router(router, prefix="/v2")
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/v2/boom/123")
+    assert response.status_code == 500
+    (event,) = stderr_events(capsys, "http_request")
+    assert event["route"] == "/v2/boom/{item_id}"
+    assert event["status"] == 500
 
 
 def test_access_event_carries_request_id(capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -504,14 +504,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/3ca813cbacb23ab6fe46ff38a9b5ef8e73e970c8051f2ce903aacafe0446/gitpython-3.1.62.tar.gz", hash = "sha256:1791de66309bc0c7cfca40bf8d2e3de7ca091cbf94e6051be1ad0722c61062af", size = 231728, upload-time = "2026-09-07T02:57:21.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0b/29d7965215f8ef830a7ca1f42997fe13e5693d85e9edb18f938d063ef5f2/gitpython-3.1.62-py3-none-any.whl", hash = "sha256:7002251225e10e29d2e1f49e6532613fe5d5d9f0b6f1f02997a52b38fe56899e", size = 222753, upload-time = "2026-09-07T02:57:19.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The latest-dependency canary fails because FastAPI 0.137+ keeps the original included route in the request scope. Access logs therefore report `/projects` instead of `/v1/projects`. This restores the complete matched route template and updates the vulnerable transitive GitPython dependency.

## Changes made

- Read FastAPI's effective route context for included routes, with the existing route lookup as the fallback for older FastAPI. Unknown routes still log `route: null`; concrete request paths never become route labels.
- Add five regression cases covering nested routers, the same router included under two prefixes, parameterized paths, a proxy `root_path`, and handler failures.
- Update only GitPython from 3.1.58 to 3.1.62 in `uv.lock`. GitPython remains a development dependency through Tach. This addresses the five reported GitPython security alerts.

## Testing performed

- Reproduced the original assertion failure with the latest dependency graph. All five new regression cases also failed before the middleware fix.
- Isolated the routing change with Starlette held at 1.6.0: FastAPI 0.136.3 retains the full route on the original route object; 0.137.0 puts it in the effective context.
- All 13 logging tests pass with both the committed dependency graph and the latest graph.
- `just check`: passed, including 332 tests and 11 snapshots.
- Latest-dependency hermetic suite on Python 3.13: 336 passed, 3 skipped, 11 snapshots passed.
- `just audit`: no known vulnerabilities found across the locked dependency graph.
- [Ordinary PR CI](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34723503550): passed, including Linux on Python 3.13/3.14, macOS, Windows, and `ci-ok`.
- [Dependency canary](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34723527074): passed on Python 3.13 and 3.14; each job ran 338 passing tests, 1 skip, and 11 passing snapshots with FastAPI 0.141.1, Starlette 1.6.0, and GitPython 3.1.62.
- [Template Press bootstrap acceptance](https://github.com/smorinlabs/py-launch-blueprint/actions/runs/34723503562) and `press-verify`: passed.
- Lefthook pre-commit, commit-msg, and pre-push checks: passed.

## Reviewer notes

FastAPI does not expose a public accessor for the request's effective route context. The compatibility lookup is confined to the access logger and documented there; the recurring dependency canary covers this integration. There are no route registration, API schema, or workflow changes.

Codex, Copilot, and CodeRabbit reported no actionable code findings. CodeRabbit also emitted an advisory docstring-coverage warning. The changed production logger already has a docstring and explanatory comments; the regression tests follow this module's existing descriptive-name style. No documentation-only test edits were added for that advisory.
